### PR TITLE
Changed all occurences of numpy.rank() to numpy.ndim()

### DIFF
--- a/lib/climt/component.py
+++ b/lib/climt/component.py
@@ -48,10 +48,10 @@ class Component:
 
         # Create output file
         self.Io.createOutputFile(self.State, self.Params.value)
-        
+
         # Write out initial state
         if not self.Io.Appending: self.write()
-            
+
         # Initialize plotting facilities
         self.Plot = Plot()
 
@@ -60,7 +60,7 @@ class Component:
 
         # Notify user of unused input quantities
         self._checkUnused(kwargs)
-                
+
         # Set some redundant attributes (mainly for backward compatibility)
         self.nlon = self.Grid['nlon']
         self.nlat = self.Grid['nlat']
@@ -76,7 +76,7 @@ class Component:
         if not ForcedCompute:
             freq = self.UpdateFreq
             time = self.State.ElapsedTime
-            if int(time/freq) == int((time-self['dt'])/freq): return 
+            if int(time/freq) == int((time-self['dt'])/freq): return
 
         # Set up union of State, Grid and Params
         Input = {}
@@ -88,7 +88,7 @@ class Component:
 
         # For semimplicit time stepping, append previous (old) time level to Input dict
         if self.SteppingScheme == 'semi-implicit':
-            for key in self.Prognostic: Input[key+'old'] = self.State.Old[key]        
+            for key in self.Prognostic: Input[key+'old'] = self.State.Old[key]
 
         # List of arguments to be passed to extension
         args = [ Input[key] for key in self.ToExtension ]
@@ -107,24 +107,24 @@ class Component:
             if key in self.Inc: self.Inc.pop(key)
             if key in Output: Output.pop(key)
 
-        # Update State 
+        # Update State
         self.State.update(Output)
         for key in Output: exec('self.'+key+'=Output[key]')
 
         # No further need for input dictionary
         del(Input)
-        
+
     def step(self, RunLength=1, Inc={}):
         """
         Advances component one timestep and writes to output file if necessary.
         Inc is an externally-specified set of increments added to the internally-computed
-        increments at each time step. 
+        increments at each time step.
         """
 
         # If RunLength is integer, interpret as number of time steps
         if type(RunLength) is type(1):
             NSteps = RunLength
-            
+
         # If RunLength is float, interpret as length of run in seconds
         if type(RunLength) is type(1.):
             NSteps = int(RunLength/self['dt'])
@@ -136,10 +136,10 @@ class Component:
                     self.Inc[key] += Inc[key]
                 else:
                     self.Inc[key] = Inc[key]
-            
+
             # Avance prognostics 1 time step
             self.State.advance(self)
-            
+
             # Bring diagnostics and increments up to date
             self.compute()
 
@@ -147,7 +147,7 @@ class Component:
             self['calday'] += self['dt']/self['lod']
             if self['calday'] > self['daysperyear']:
                 self['calday'] -= self['daysperyear']
-            
+
             # Write to file, if it's time to
             dt   = self.Params['dt']
             time = self.State.ElapsedTime
@@ -158,10 +158,10 @@ class Component:
             if self.Monitor.Monitoring:
                 freq = self.Monitor.MonitorFreq
                 if int(time/freq) != int((time-dt)/freq): self.Monitor.refresh(self)
-        
+
     def __call__(self,**kwargs):
         """
-        # Provides a simple interface to extension, useful e.g. for diagnostics. 
+        # Provides a simple interface to extension, useful e.g. for diagnostics.
         """
         # Re-initialize parameters, grid and state
         self.Params  = Parameters(**kwargs)
@@ -192,7 +192,7 @@ class Component:
 
     def plot(self, *FieldKeys):
         self.Plot(self, *FieldKeys)
-        
+
     def setFigure(self, FigureNumber=None):
         self.Plot.setFigure(FigureNumber)
 
@@ -227,10 +227,10 @@ class Component:
             and key not in self.Grid   \
             and key not in KnownFields \
             and key not in io_keys \
-            and key not in monitor_keys: 
+            and key not in monitor_keys:
                 unused.append(key)
 
-        if len(unused) > 0: 
+        if len(unused) > 0:
            if len(unused) == 1: suffix = 'y'
            else              : suffix = 'ies'
            print '\n ++++ CliMT.'+self.Name+'.initialize: WARNING: Input quantit%s %s not used.\n' \
@@ -256,10 +256,10 @@ class Component:
         # See if axis was supplied in input
         n = None
         if AxisName in kwargs:
-            if rank(array(kwargs[AxisName])) == 0:
+            if ndim(array(kwargs[AxisName])) == 0:
                 n = 1
             else:
-                assert rank(array(kwargs[AxisName])) == 1, \
+                assert ndim(array(kwargs[AxisName])) == 1, \
                     '\n\n ++++ CliMT.%s.init: input %s must be rank 1' % (self.Name,AxisName)
                 n = len(array(kwargs[AxisName]))
 
@@ -269,7 +269,7 @@ class Component:
                 if key in KnownFields:
                     if KnownFields[key][2] == '2D' and AxisName != 'lev':
                         i = ['lat','lon'].index(AxisName)
-                        try:    n = array(kwargs[key]).shape[i] 
+                        try:    n = array(kwargs[key]).shape[i]
                         except: n = 1
                     elif KnownFields[key][2] == '3D':
                         i = ['lev','lat','lon'].index(AxisName)
@@ -313,4 +313,3 @@ class Component:
             self.State[key]=reshape(value,self.Grid.Shape3D)
             return
         else: raise IndexError,'\n\n CliMT.State: %s not in Params, Grid or State' % str(key)
-

--- a/lib/climt/plot.py
+++ b/lib/climt/plot.py
@@ -15,11 +15,11 @@ try:
     # increase vertical gap between plots
     pylab.rcParams['figure.subplot.hspace']=0.3
     # turn on interactive mode
-    pylab.ion() 
+    pylab.ion()
     gotMatplotlib = True
 except:
     if not Lite: print '\n ++++ CliMT: WARNING: matplotlib.pylab ' \
-       +'could not be loaded, so no runtime monitoring !\n' 
+       +'could not be loaded, so no runtime monitoring !\n'
     gotMatplotlib = False
 
 from numpy import *
@@ -42,13 +42,13 @@ def _figureSetUp(FieldKeys, Component):
         Subplot = Subplots[key]
         exec('pylab.subplot(%s)' % Subplot)
         Figure[key] = Panel(Component, key, Subplot)
-        
+
     return Figure
 
 class Plot:
     """
     Enables plotting of up to 4 variables.
-    """    
+    """
     def __init__(self):
         pass
 
@@ -57,7 +57,7 @@ class Plot:
         Plots fields indicated by FieldKeys
         """
         if not gotMatplotlib: return
-        
+
         if len(FieldKeys) == 0: return
         # Clear figure
         pylab.clf()
@@ -89,7 +89,7 @@ class Monitor:
         if not gotMatplotlib:
             self.Monitoring = False
             return
-        
+
         # List of fields to monitor
         try:    self.FieldKeys = kwargs['MonitorFields']
         except: self.FieldKeys = []
@@ -98,7 +98,7 @@ class Monitor:
         for key in self.FieldKeys:
             assert key in Component.State, \
                    '\n\n ++++ CliMT.monitor: %s not in component' % key
-            if rank(Component[key]) == 0:
+            if ndim(Component[key]) == 0:
                 print '\n\n ++++ CliMT.monitor: WARNING: cannot '\
                       +'monitor scalar variable %s' % key
                 self.FieldKeys.pop(self.FieldKeys.index(key))
@@ -136,12 +136,12 @@ class Monitor:
             Panel = self.Figure[key]
 
             # If Field is 3D, show zonal average
-            if rank(Field) == 3:
+            if ndim(Field) == 3:
                 Field = average(Field,axis=2)
                 Field = squeeze(Field)
 
             # Reset data
-            if rank(Field) == 1:
+            if ndim(Field) == 1:
                 if min(Field) == max(Field) == 0.: Field=Field+1.e-7
                 MinVal = min(Field) - 0.01*abs(min(Field))
                 MaxVal = max(Field) + 0.01*abs(max(Field))
@@ -151,7 +151,7 @@ class Monitor:
                 else:
                     Panel.handle.set_ydata(Field)
                     Panel.axes.set_ylim([MinVal, MaxVal])
-            if rank(Field) == 2:
+            if ndim(Field) == 2:
                 if Panel.orientation == 0:
                     Panel.handle.set_data(Field[::-1])
                 if Panel.orientation == 1:
@@ -175,7 +175,7 @@ class Panel:
     Configures single panel of monitor display.
     """
     def __init__(self, Component, FieldKey, Subplot):
-        
+
         # get Field value
         Field = Component.State[FieldKey]
         Dims  = KnownFields[FieldKey][2]
@@ -191,7 +191,7 @@ class Panel:
 
         # If Field is 3D, show zonal average
         Field = squeeze(Field)
-        if rank(Field) == 3:
+        if ndim(Field) == 3:
             Field = average(Field,axis=2)
             Field = squeeze(Field)
             AxisKey.pop(2)
@@ -202,7 +202,7 @@ class Panel:
         for key in AxisKey:
             AxisName.append(Component.Grid.long_name[key])
             AxisVal.append(Component.Grid[key])
-        
+
         # Get handles to figure and properties
         if len(AxisName) == 1:
             if min(Field) == max(Field) == 0.: Field=Field+1.e-7
@@ -248,8 +248,8 @@ class Panel:
             self.handle.set_norm(None)
 
         # Title
-        self.TitleTemplate = '%s  [%s]' % (FieldKey,KnownFields[FieldKey][1]) + ' %6.2f days' 
-        if len(AxisName) == 2: self.TitleTemplate = self.TitleTemplate + '\n min=%g max=%g' 
+        self.TitleTemplate = '%s  [%s]' % (FieldKey,KnownFields[FieldKey][1]) + ' %6.2f days'
+        if len(AxisName) == 2: self.TitleTemplate = self.TitleTemplate + '\n min=%g max=%g'
         day = Component.State.ElapsedTime/86400.
         try:
             TitleText = self.TitleTemplate % day
@@ -262,7 +262,7 @@ class Panel:
 if __name__=='__main__':
 
     import climt
-    r=climt.radiation(lat=arange(0.,90.,10.))    
+    r=climt.radiation(lat=arange(0.,90.,10.))
     m=Monitor(r, MonitorFields=['T','Ts'])
     for i in range(10):
         r.step()

--- a/lib/climt/utils.py
+++ b/lib/climt/utils.py
@@ -22,12 +22,11 @@ def demean(a,axis=0):
     assert axis <= len(shape(a)), \
                   '\n\n ++++ CliMT.utils.demean: axis index out of range'
 
-    if rank(a)==1: return a - average(a)
-    
-    x=[':']*rank(a)
+    if ndim(a)==1: return a - average(a)
+
+    x=[':']*ndim(a)
     x[axis]='NewAxis'
-    s='['+'%s,'*(rank(a)-1)+'%s]'
+    s='['+'%s,'*(ndim(a)-1)+'%s]'
     sx = s % tuple(x)
     exec('a = a - average(a,axis=axis)'+sx)
     return a
-


### PR DESCRIPTION
A very simple change:
I replaced all occurrences of `numpy.rank()` with `numpy.ndim()` since `rank()` is deprecated in `numpy` version 1.9 and above (see http://docs.scipy.org/doc/numpy/release.html)
This suppresses an annoying warning message and presumably avoids future compatibility issues.

Basically I'm just using this as an excuse to learn how to make a pull request on github.
