### PR TITLE
Fixed bug in python wrapper for thermodyn.wsflatau. The wrapper was n…

### DIFF
--- a/lib/climt/thermodyn.py
+++ b/lib/climt/thermodyn.py
@@ -79,7 +79,7 @@ def wsflatau(T,p,i=None,Rd=None,Rv=None):
   if i   is None: i   = 1
   if Rd  is None: Rd  = Parameters()['Rd']
   if Rv  is None: Rv  = Parameters()['Rv']
-  return squeeze(_thermodyn.wsflatau(T,p,i))
+  return squeeze(_thermodyn.wsflatau(Rd,Rv,T,p,i))
 
 def tdew(p,q):
   '''


### PR DESCRIPTION
The wrapper was not passing necessary Rd and Rv to the fortran subroutine.
